### PR TITLE
change ThriftHiveMetaStoreClientFactory to create a new thrift client…

### DIFF
--- a/hms-lambda-func/src/main/java/com/amazonaws/athena/hms/ThriftHiveMetaStoreClientFactory.java
+++ b/hms-lambda-func/src/main/java/com/amazonaws/athena/hms/ThriftHiveMetaStoreClientFactory.java
@@ -29,19 +29,11 @@ import java.net.URISyntaxException;
 public class ThriftHiveMetaStoreClientFactory implements HiveMetaStoreClientFactory
 {
   private final HiveMetaStoreConf conf;
-  private final HiveMetaStoreClient client;
 
   public ThriftHiveMetaStoreClientFactory()
   {
     // load configuration from a property file and override with environment variables
     this.conf = HiveMetaStoreConf.loadAndOverrideWithEnvironmentVariables();
-    try {
-      // create the thrift Hive Metastore client
-      this.client = new ThriftHiveMetaStoreClient(conf.toHiveConf());
-    }
-    catch (TException | IOException | InterruptedException | LoginException | URISyntaxException e) {
-      throw new RuntimeException("Failed to create HiveMetaStoreClient", e);
-    }
   }
 
   @Override
@@ -50,10 +42,21 @@ public class ThriftHiveMetaStoreClientFactory implements HiveMetaStoreClientFact
     return conf;
   }
 
+  private ThriftHiveMetaStoreClient createClient()
+  {
+    try {
+      // create the thrift Hive Metastore client
+      return new ThriftHiveMetaStoreClient(conf.toHiveConf());
+    }
+    catch (TException | IOException | InterruptedException | LoginException | URISyntaxException e) {
+      throw new RuntimeException("Failed to create HiveMetaStoreClient", e);
+    }
+  }
+
   @Override
   public HiveMetaStoreClient getHiveMetaStoreClient()
   {
-    return client;
+    return createClient();
   }
 
   @Override


### PR DESCRIPTION
… for each api handler

*Issue #, if available:*

*Description of changes:*
We saw connections to thrift server could be reset or closed on customer side. To reduce the chance that we use a stale connection if the lambda droplet has been running for a long time, we always establish a new thrift connection to thrift server for each API call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
