### PR TITLE
Bump jackson and hive versions, remove log4j dependency

### DIFF
--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -107,10 +107,6 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
@@ -135,7 +131,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.6</version>
+            <version>2.9.10.4</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-handler/pom.xml
+++ b/hms-lambda-handler/pom.xml
@@ -102,10 +102,6 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
@@ -130,7 +126,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.6</version>
+            <version>2.9.10.4</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-layer/pom.xml
+++ b/hms-lambda-layer/pom.xml
@@ -102,10 +102,6 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
@@ -130,7 +126,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.6</version>
+            <version>2.9.10.4</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.target>1.8</javac.target>
-    <hive.version>2.3.0</hive.version>
+    <hive.version>2.3.4</hive.version>
     <hadoop.version>2.7.4</hadoop.version>
     <commons-cli.version>1.4</commons-cli.version>
   </properties>
@@ -146,16 +146,6 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.2</version>
-      </dependency>
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-1.2-api</artifactId>
-        <version>2.6.2</version>
       </dependency>
       <dependency>
         <groupId>com.lmax</groupId>


### PR DESCRIPTION
*Issue #, if available:*
tt E305273554

*Description of changes:*
Bumping jackson and hive versions due to vulnerabilities. Log4j was not being used in the code (and required a major version bump) so I removed it for now.

*Testing:*
built changes into ehms_release_test_glue_integration branch and ran ehms release tests, passing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
