### PR TITLE
Bump jackson minor version, re-add log4j 1

### DIFF
--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-func/pom.xml
+++ b/hms-lambda-func/pom.xml
@@ -107,6 +107,10 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>

--- a/hms-lambda-handler/pom.xml
+++ b/hms-lambda-handler/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-handler/pom.xml
+++ b/hms-lambda-handler/pom.xml
@@ -102,6 +102,10 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>

--- a/hms-lambda-layer/pom.xml
+++ b/hms-lambda-layer/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.4</version>
+            <version>2.9.10.5</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/hms-lambda-layer/pom.xml
+++ b/hms-lambda-layer/pom.xml
@@ -102,6 +102,10 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,16 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-1.2-api</artifactId>
+        <version>2.6.2</version>
+      </dependency>
+      <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
         <version>3.4.2</version>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump jackson minor version due to security alert
Re-add log4j 1 until we can correctly migrate to log4j 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
